### PR TITLE
Discard module path from file logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ It comes with a multiplatform client application.
 
 Rust/Flutter version of Vestibule.
 
+## ⚠️ Breaking change ⚠️
+
+From version 1.8.0 atrium encrypted file format changed to ensure future crypto agility.
+To migrate from 1.7.x to 1.8+ use the `backend/src/bin/convert_encryption.rs` binary to convert encrypted files to the new format.
+The encryption key is not needed since it is only an encryption type prefix added to every files.
+
 ## Installation
 
 Example service installation can be found [HERE](https://github.com/nicolaspernoud/atrium/blob/main/scripts/systemd/install_atrium.sh).

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "atrium"
-version = "1.8.0"
+version = "0.8.0"
 edition = "2024"
 license = "AGPL-3.0-or-later"
+default-run = "atrium"
 
 [lib]
 path = "src/lib.rs"
@@ -51,7 +52,7 @@ serde_yaml_ng = "0.10.0"
 sha2 = { default-features = false, version = "0.11.0" }
 sysinfo = { default-features = false, version = "0.38.4", features = ["disk", "system"] }
 time = { default-features = false, version = "0.3.47" }
-tokio = { version = "1.50.0", features = ["full"], default-features = false }
+tokio = { version = "1.51.0", features = ["full"], default-features = false }
 tokio-stream = { version = "0.1.18", default-features = false }
 tokio-util = { version = "0.7.18", default-features = false }
 tower = { default-features = false, version = "0.5.3", features = ["util"] }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atrium"
-version = "1.7.1"
+version = "1.8.0"
 edition = "2024"
 license = "AGPL-3.0-or-later"
 
@@ -12,36 +12,16 @@ path = "src/main.rs"
 name = "atrium"
 
 [dependencies]
-argon2 = { features = [
-    "alloc",
-    "password-hash",
-], default-features = false, version = "0.5.3" }
-async_zip = { features = [
-    "deflate",
-    "tokio",
-], default-features = false, version = "0.0.18" }
+argon2 = { features = ["alloc", "password-hash"], default-features = false, version = "0.5.3" }
+async_zip = { features = ["deflate", "tokio"], default-features = false, version = "0.0.18" }
 async-stream = "0.3.6"
 async-walkdir = "2.1.0"
-aws-lc-rs = { version = "1.16.2", default-features = false, features = [
-    "bindgen",
-] }
-axum = { version = "0.8.8", features = [
-    "http2",
-    "json",
-    "query",
-    "tokio",
-], default-features = false }
-axum-extra = { version = "0.12.5", features = [
-    "cookie-private",
-    "typed-header",
-], default-features = false }
-axum-server = { version = "0.8.0", default-features = false, features = [
-    "tls-rustls",
-] }
+aws-lc-rs = { version = "1.16.2", default-features = false, features = ["bindgen"] }
+axum = { version = "0.8.8", features = ["http2", "json", "query", "tokio"], default-features = false }
+axum-extra = { version = "0.12.5", features = ["cookie-private", "typed-header"], default-features = false }
+axum-server = { version = "0.8.0", default-features = false, features = ["tls-rustls"] }
 base64ct = { version = "1.8.3", features = ["alloc"] }
-chacha20poly1305 = { version = "0.10.1", features = [
-    "stream",
-], default-features = false }
+chacha20poly1305 = { version = "0.10.1", features = ["stream"], default-features = false }
 chrono = { default-features = false, version = "0.4.44" }
 filetime = "0.2.27"
 futures = { default-features = false, version = "0.3.32" }
@@ -49,57 +29,27 @@ futures-util = { default-features = false, version = "0.3.32" }
 headers = "0.4.1"
 http = "1.4.0"
 http-body-util = "0.1.3"
-hyper = { version = "1.8.1", default-features = false }
-hyper-hickory = { version = "0.8.0", default-features = false, features = [
-    "system-config",
-    "tokio",
-] }
-hyper-rustls = { version = "0.27.7", features = [
-    "aws-lc-rs",
-    "http1",
-    "http2",
-    "tls12",
-    "webpki-tokio",
-], default-features = false }
-hyper-util = { version = "0.1.20", features = [
-    "client-legacy",
-    "http1",
-    "tokio",
-], default-features = false }
-jsonwebtoken = { version = "10.3.0", features = [
-    "aws_lc_rs",
-], default-features = false }
+hyper = { version = "1.9.0", default-features = false }
+hyper-hickory = { version = "0.8.0", default-features = false, features = ["system-config", "tokio"] }
+hyper-rustls = { version = "0.27.7", features = ["aws-lc-rs", "http1", "http2", "tls12", "webpki-tokio"], default-features = false }
+hyper-util = { version = "0.1.20", features = ["client-legacy", "http1", "tokio"], default-features = false }
+jsonwebtoken = { version = "10.3.0", features = ["aws_lc_rs"], default-features = false }
 maxminddb = "0.27.3"
 mime_guess = { default-features = false, version = "2.0.5" }
 oauth2 = { version = "5.0.0", default-features = false }
 percent-encoding = { default-features = false, version = "2.3.2" }
 quick-xml = "0.39.2"
-rand = { default-features = false, version = "0.10.0", features = [
-    "thread_rng",
-] }
-rcgen = { version = "0.14.7", default-features = false, optional = true, features = [
-    "aws_lc_rs",
-    "crypto",
-    "pem",
-] }
+rand = { default-features = false, version = "0.10.0", features = ["thread_rng"] }
+rcgen = { version = "0.14.7", default-features = false, optional = true, features = ["aws_lc_rs", "crypto", "pem"] }
 rust-embed = { version = "8.11.0", features = ["axum"] }
-rustls = { default-features = false, version = "0.23.37", features = [
-    "aws_lc_rs",
-] }
-rustls-acme = { version = "0.15.1", features = [
-    "aws-lc-rs",
-    "axum",
-    "webpki-roots",
-], default-features = false }
+rustls = { default-features = false, version = "0.23.37", features = ["aws_lc_rs"] }
+rustls-acme = { version = "0.15.1", features = ["aws-lc-rs", "axum", "webpki-roots"], default-features = false }
 rustls-pki-types = { version = "1.14.0" }
 serde = { version = "1.0.228", default-features = false }
 serde_json = { default-features = false, version = "1.0.149" }
 serde_yaml_ng = "0.10.0"
-sha2 = { default-features = false, version = "0.10.9" }
-sysinfo = { default-features = false, version = "0.38.4", features = [
-    "disk",
-    "system",
-] }
+sha2 = { default-features = false, version = "0.11.0" }
+sysinfo = { default-features = false, version = "0.38.4", features = ["disk", "system"] }
 time = { default-features = false, version = "0.3.47" }
 tokio = { version = "1.50.0", features = ["full"], default-features = false }
 tokio-stream = { version = "0.1.18", default-features = false }
@@ -107,21 +57,12 @@ tokio-util = { version = "0.7.18", default-features = false }
 tower = { default-features = false, version = "0.5.3", features = ["util"] }
 tower-http = { version = "0.6.8", features = ["fs"], default-features = false }
 tower-service = "0.3.3"
-tracing = { default-features = false, version = "0.1.44", features = [
-    "attributes",
-] }
+tracing = { default-features = false, version = "0.1.44", features = ["attributes"] }
 tracing-appender = "0.2.4"
-tracing-subscriber = { version = "0.3.23", features = [
-    "ansi",
-    "env-filter",
-    "local-time",
-], default-features = false }
+tracing-subscriber = { version = "0.3.23", features = ["ansi", "env-filter", "local-time"], default-features = false }
 trim-in-place = "0.1.7"
 urlencoding = "2.1.3"
-uuid = { version = "1.22.0", features = [
-    "fast-rng",
-    "v4",
-], default-features = false }
+uuid = { version = "1.23.0", features = ["fast-rng", "v4"], default-features = false }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 iptables = "0.6.0"
@@ -133,13 +74,7 @@ self_signed = ["dep:rcgen"]
 [dev-dependencies]
 async-tungstenite = { version = "0.34.0", features = ["tokio-runtime"] }
 axum = { version = "0.8.8", features = ["__private"], default-features = false }
-reqwest = { version = "0.13.2", default-features = false, features = [
-    "cookies",
-    "gzip",
-    "json",
-    "native-tls",
-    "stream",
-] }
+reqwest = { version = "0.13.2", default-features = false, features = ["cookies", "gzip", "json", "native-tls", "stream"] }
 tempfile = "3.27.0"
 tungstenite = "0.29.0"
 

--- a/backend/src/bin/convert_encryption.rs
+++ b/backend/src/bin/convert_encryption.rs
@@ -1,13 +1,13 @@
 use filetime::{FileTime, set_file_times};
 use std::env;
 use std::fs::{self, File};
-use std::io::{Read, Write};
+use std::io::Write;
 use std::path::Path;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
-        eprintln!("Usage: {} <encrypted_dir>", args.get(0).expect("args"));
+        eprintln!("Usage: {} <encrypted_dir>", args.first().expect("args"));
         std::process::exit(1);
     }
 
@@ -61,9 +61,6 @@ fn convert_file(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Converting: {:?}", path);
 
-    let mut content = Vec::new();
-    file.read_to_end(&mut content)?;
-
     let mut new_path = path.to_path_buf();
     let original_file_name = path.file_name().ok_or("Invalid file name")?;
     let mut new_file_name = original_file_name.to_os_string();
@@ -75,7 +72,7 @@ fn convert_file(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
         let cipher_type: u8 = 0; // XChaCha20Poly1305_1M
 
         new_file.write_all(&[cipher_type])?;
-        new_file.write_all(&content)?;
+        std::io::copy(&mut file, &mut new_file)?;
     }
 
     fs::rename(&new_path, path)?;

--- a/backend/src/bin/convert_encryption.rs
+++ b/backend/src/bin/convert_encryption.rs
@@ -1,0 +1,87 @@
+use filetime::{FileTime, set_file_times};
+use std::env;
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::path::Path;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: {} <encrypted_dir>", args.get(0).expect("args"));
+        std::process::exit(1);
+    }
+
+    let dir_path = Path::new(args.get(1).expect("args"));
+    if !dir_path.is_dir() {
+        eprintln!("Error: {} is not a directory", args.get(1).expect("args"));
+        std::process::exit(1);
+    }
+
+    convert_dir(dir_path)?;
+
+    println!("Conversion completed successfully.");
+    Ok(())
+}
+
+fn convert_dir(dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            convert_dir(&path)?;
+        } else if path.is_file() {
+            convert_file(&path)?;
+        }
+    }
+    Ok(())
+}
+
+fn convert_file(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let mut file = File::open(path)?;
+    let metadata = file.metadata()?;
+    let len = metadata.len();
+
+    if len < 19 && len > 0 {
+        eprintln!(
+            "ALERT: File {:?} is too small to be a valid old-format encrypted file (size: {} bytes)",
+            path, len
+        );
+    }
+
+    // Old format: 19 bytes nonce + chunks
+    // New format: 1 byte cipher type + 19 bytes nonce + chunks
+
+    if len == 0 {
+        return Ok(());
+    }
+
+    // Capture metadata
+    let atime = FileTime::from_last_access_time(&metadata);
+    let mtime = FileTime::from_last_modification_time(&metadata);
+
+    println!("Converting: {:?}", path);
+
+    let mut content = Vec::new();
+    file.read_to_end(&mut content)?;
+
+    let mut new_path = path.to_path_buf();
+    let original_file_name = path.file_name().ok_or("Invalid file name")?;
+    let mut new_file_name = original_file_name.to_os_string();
+    new_file_name.push(".tmp_convert");
+    new_path.set_file_name(new_file_name);
+
+    {
+        let mut new_file = File::create(&new_path)?;
+        let cipher_type: u8 = 0; // XChaCha20Poly1305_1M
+
+        new_file.write_all(&[cipher_type])?;
+        new_file.write_all(&content)?;
+    }
+
+    fs::rename(&new_path, path)?;
+
+    // Restore metadata
+    set_file_times(path, atime, mtime)?;
+
+    Ok(())
+}

--- a/backend/src/davs/crypto.rs
+++ b/backend/src/davs/crypto.rs
@@ -69,6 +69,19 @@ impl CipherType {
         (num_chunks - 1) * plain_chunk_size
             + (last_chunk_size.saturating_sub(overhead))
     }
+
+    pub fn create_cipher(&self, key: &[u8; 32], nonce: &[u8]) -> Box<dyn Cipher> {
+        match self {
+            CipherType::XChaCha20Poly1305_1M => {
+                let aead = XChaCha20Poly1305::new(key.into());
+                let stream_encryptor = stream::StreamBE32::from_aead(aead, nonce.into());
+                Box::new(XChaCha20Poly1305Cipher {
+                    stream_encryptor,
+                    cipher_type: *self,
+                })
+            }
+        }
+    }
 }
 
 pub trait Cipher: Send + Sync {
@@ -105,22 +118,6 @@ impl Cipher for XChaCha20Poly1305Cipher {
     }
 }
 
-pub fn create_cipher(
-    cipher_type: CipherType,
-    key: &[u8; 32],
-    nonce: &[u8],
-) -> Box<dyn Cipher> {
-    match cipher_type {
-        CipherType::XChaCha20Poly1305_1M => {
-            let aead = XChaCha20Poly1305::new(key.into());
-            let stream_encryptor = stream::StreamBE32::from_aead(aead, nonce.into());
-            Box::new(XChaCha20Poly1305Cipher {
-                stream_encryptor,
-                cipher_type,
-            })
-        }
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/backend/src/davs/crypto.rs
+++ b/backend/src/davs/crypto.rs
@@ -1,0 +1,163 @@
+use chacha20poly1305::{
+    XChaCha20Poly1305,
+    aead::{
+        KeyInit,
+        stream::{self, StreamBE32, NewStream, StreamPrimitive},
+    },
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CipherType {
+    XChaCha20Poly1305_1M = 0,
+}
+
+impl CipherType {
+    pub fn from_u8(v: u8) -> Result<Self, String> {
+        match v {
+            0 => Ok(CipherType::XChaCha20Poly1305_1M),
+            _ => Err(format!("Unknown cipher type: {}", v)),
+        }
+    }
+
+    pub fn nonce_size(&self) -> usize {
+        match self {
+            CipherType::XChaCha20Poly1305_1M => 19,
+        }
+    }
+
+    pub fn overhead(&self) -> usize {
+        match self {
+            CipherType::XChaCha20Poly1305_1M => 16,
+        }
+    }
+
+    pub fn plain_chunk_size(&self) -> usize {
+        match self {
+            CipherType::XChaCha20Poly1305_1M => 1_000_000,
+        }
+    }
+
+    pub fn encrypted_chunk_size(&self) -> usize {
+        self.plain_chunk_size() + self.overhead()
+    }
+
+    pub fn header_size(&self) -> usize {
+        1 + self.nonce_size()
+    }
+
+    pub fn encrypted_chunk_start(&self, dec_offset: u64) -> u64 {
+        let chunk_idx = dec_offset / self.plain_chunk_size() as u64;
+        self.header_size() as u64 + chunk_idx * self.encrypted_chunk_size() as u64
+    }
+
+    pub fn decrypted_size(&self, enc_size: u64) -> u64 {
+        let header_size = self.header_size() as u64;
+        let encrypted_chunk_size = self.encrypted_chunk_size() as u64;
+        let plain_chunk_size = self.plain_chunk_size() as u64;
+        let overhead = self.overhead() as u64;
+
+        if enc_size <= header_size {
+            return 0;
+        }
+        let enc_size_without_header = enc_size - header_size;
+        let num_chunks = enc_size_without_header.div_ceil(encrypted_chunk_size);
+        if num_chunks == 0 {
+            return 0;
+        }
+        let last_chunk_size = enc_size_without_header - (num_chunks - 1) * encrypted_chunk_size;
+        (num_chunks - 1) * plain_chunk_size
+            + (last_chunk_size.saturating_sub(overhead))
+    }
+}
+
+pub trait Cipher: Send + Sync {
+    fn encrypt(&mut self, chunk_idx: u32, is_last: bool, plaintext: &[u8]) -> Result<Vec<u8>, String>;
+    fn decrypt(&mut self, chunk_idx: u32, is_last: bool, ciphertext: &[u8]) -> Result<Vec<u8>, String>;
+    fn plain_chunk_size(&self) -> usize;
+    fn cipher_type(&self) -> CipherType;
+}
+
+struct XChaCha20Poly1305Cipher {
+    stream_encryptor: StreamBE32<XChaCha20Poly1305>,
+    cipher_type: CipherType,
+}
+
+impl Cipher for XChaCha20Poly1305Cipher {
+    fn encrypt(&mut self, chunk_idx: u32, is_last: bool, plaintext: &[u8]) -> Result<Vec<u8>, String> {
+        self.stream_encryptor
+            .encrypt(chunk_idx, is_last, plaintext)
+            .map_err(|e: chacha20poly1305::aead::Error| e.to_string())
+    }
+
+    fn decrypt(&mut self, chunk_idx: u32, is_last: bool, ciphertext: &[u8]) -> Result<Vec<u8>, String> {
+        self.stream_encryptor
+            .decrypt(chunk_idx, is_last, ciphertext)
+            .map_err(|e: chacha20poly1305::aead::Error| e.to_string())
+    }
+
+    fn plain_chunk_size(&self) -> usize {
+        self.cipher_type.plain_chunk_size()
+    }
+
+    fn cipher_type(&self) -> CipherType {
+        self.cipher_type
+    }
+}
+
+pub fn create_cipher(
+    cipher_type: CipherType,
+    key: &[u8; 32],
+    nonce: &[u8],
+) -> Box<dyn Cipher> {
+    match cipher_type {
+        CipherType::XChaCha20Poly1305_1M => {
+            let aead = XChaCha20Poly1305::new(key.into());
+            let stream_encryptor = stream::StreamBE32::from_aead(aead, nonce.into());
+            Box::new(XChaCha20Poly1305Cipher {
+                stream_encryptor,
+                cipher_type,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decrypted_size() {
+        let cipher_type = CipherType::XChaCha20Poly1305_1M;
+        let overhead = cipher_type.overhead() as u64;
+        let plain_chunk_size = cipher_type.plain_chunk_size() as u64;
+        let encrypted_chunk_size = plain_chunk_size + overhead;
+        let header_size = cipher_type.header_size() as u64;
+
+        assert_eq!(cipher_type.decrypted_size(0), 0);
+        assert_eq!(cipher_type.decrypted_size(header_size + overhead), 0);
+        assert_eq!(
+            cipher_type.decrypted_size(header_size + 3 * encrypted_chunk_size),
+            3 * plain_chunk_size
+        );
+        assert_eq!(
+            cipher_type.decrypted_size(
+                header_size + 3 * encrypted_chunk_size + overhead + 150
+            ),
+            3 * plain_chunk_size + 150
+        );
+    }
+
+    #[test]
+    fn test_encrypted_chunk_start() {
+        let cipher_type = CipherType::XChaCha20Poly1305_1M;
+        let plain_chunk_size = cipher_type.plain_chunk_size() as u64;
+        let encrypted_chunk_size = cipher_type.encrypted_chunk_size() as u64;
+        let header_size = cipher_type.header_size() as u64;
+
+        assert_eq!(cipher_type.encrypted_chunk_start(0), header_size);
+        assert_eq!(cipher_type.encrypted_chunk_start(plain_chunk_size - 1), header_size);
+        assert_eq!(cipher_type.encrypted_chunk_start(plain_chunk_size), header_size + encrypted_chunk_size);
+        assert_eq!(cipher_type.encrypted_chunk_start(2 * plain_chunk_size + 500), header_size + 2 * encrypted_chunk_size);
+    }
+}

--- a/backend/src/davs/dav_file.rs
+++ b/backend/src/davs/dav_file.rs
@@ -1,10 +1,4 @@
-use chacha20poly1305::{
-    XChaCha20Poly1305,
-    aead::{
-        KeyInit,
-        stream::{self, NewStream, StreamBE32, StreamPrimitive},
-    },
-};
+use super::crypto::{Cipher, CipherType, create_cipher};
 use futures::ready;
 use headers::{ETag, LastModified};
 use rand::{TryRng, rngs::SysRng};
@@ -15,11 +9,6 @@ use std::{path::Path, time::SystemTime};
 use tokio::fs::{self, File};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncWrite, AsyncWriteExt, ReadBuf};
 
-const PLAIN_CHUNK_SIZE: usize = 1_000_000; // 1 MByte
-const ENCRYPTION_OVERHEAD: usize = 16;
-const ENCRYPTED_CHUNK_SIZE: usize = PLAIN_CHUNK_SIZE + ENCRYPTION_OVERHEAD;
-// Using stream::StreamBE32 with XChaCha20Poly1305 does take a 19-byte nonce prefix and internally composes a 24-byte XChaCha nonce with a 32-bit big-endian counter.
-const NONCE_SIZE: usize = 19;
 
 const BUFFER_ERROR: &str = "buffer error for encryption or decryption";
 
@@ -33,29 +22,42 @@ pub enum DavFile {
         write_buffer: Vec<u8>,
         pos: u64,
         decrypted_len: u64,
-        nonce: [u8; NONCE_SIZE],
+        nonce: Vec<u8>,
         offset_in_chunk: u32,
         read_chunk_idx: u32,
         write_chunk_idx: u32,
         seeked_after_open: bool,
-        stream_encryptor: StreamBE32<XChaCha20Poly1305>,
+        cipher: Box<dyn Cipher>,
         write_op_in_progress: bool,
     },
 }
 
 impl DavFile {
     pub async fn create(path: &Path, key: Option<[u8; 32]>) -> io::Result<DavFile> {
+        Self::create_with_cipher_type(path, key, CipherType::XChaCha20Poly1305_1M).await
+    }
+
+    pub async fn create_with_cipher_type(
+        path: &Path,
+        key: Option<[u8; 32]>,
+        cipher_type: CipherType,
+    ) -> io::Result<DavFile> {
         let mut file = fs::File::create(&path).await?;
 
         match key {
             Some(key) => {
-                let mut nonce = [0u8; NONCE_SIZE];
+                let nonce_size = cipher_type.nonce_size();
+                let mut nonce = vec![0u8; nonce_size];
                 TryRng::try_fill_bytes(&mut SysRng, &mut nonce)
                     .map_err(|e| io::Error::other(e.to_string()))?;
+
+                // Header: cipher_type (u8), nonce
+                file.write_all(&[cipher_type as u8]).await?;
                 file.write_all(&nonce).await?;
                 file.flush().await?;
-                let aead = XChaCha20Poly1305::new(key.as_ref().into());
-                let stream_encryptor = stream::StreamBE32::from_aead(aead, nonce.as_ref().into());
+
+                let cipher = create_cipher(cipher_type, &key, &nonce);
+
                 Ok(DavFile::Encrypted {
                     file: Box::new(file),
                     key,
@@ -69,7 +71,7 @@ impl DavFile {
                     read_chunk_idx: 0,
                     write_chunk_idx: 0,
                     seeked_after_open: false,
-                    stream_encryptor,
+                    cipher,
                     write_op_in_progress: false,
                 })
             }
@@ -86,15 +88,47 @@ impl DavFile {
         let metadata = file.metadata().await?;
         match key {
             Some(key) => {
-                let mut nonce = [0u8; NONCE_SIZE];
-                if metadata.len() > 0 {
-                    file.read_exact(&mut nonce).await?;
+                if metadata.len() == 0 {
+                    let cipher_type = CipherType::XChaCha20Poly1305_1M;
+                    let nonce_size = cipher_type.nonce_size();
+                    let nonce = vec![0u8; nonce_size];
+                    let cipher = create_cipher(cipher_type, &key, &nonce);
+                    return Ok(DavFile::Encrypted {
+                        file: Box::new(file),
+                        key,
+                        read_buffer: Vec::new(),
+                        encrypted_read_buffer: Vec::new(),
+                        write_buffer: Vec::new(),
+                        pos: 0,
+                        decrypted_len: 0,
+                        nonce,
+                        offset_in_chunk: 0,
+                        read_chunk_idx: 0,
+                        write_chunk_idx: 0,
+                        seeked_after_open: false,
+                        cipher,
+                        write_op_in_progress: false,
+                    });
                 }
-                let enc_size_without_nonce = metadata.len().saturating_sub(NONCE_SIZE as u64);
+
+                let mut cipher_type_byte = [0u8; 1];
+                file.read_exact(&mut cipher_type_byte).await?;
+                let cipher_type = CipherType::from_u8(cipher_type_byte[0])
+                    .map_err(io::Error::other)?;
+
+                let nonce_size = cipher_type.nonce_size();
+                let mut nonce = vec![0u8; nonce_size];
+                file.read_exact(&mut nonce).await?;
+
+                let encrypted_chunk_size = cipher_type.encrypted_chunk_size();
+                let header_size = cipher_type.header_size();
+
+                let enc_size_without_header = metadata.len().saturating_sub(header_size as u64);
                 let write_chunk_idx_initial =
-                    (enc_size_without_nonce / ENCRYPTED_CHUNK_SIZE as u64) as u32;
-                let aead = XChaCha20Poly1305::new(key.as_ref().into());
-                let stream_encryptor = stream::StreamBE32::from_aead(aead, nonce.as_ref().into());
+                    (enc_size_without_header / encrypted_chunk_size as u64) as u32;
+
+                let cipher = create_cipher(cipher_type, &key, &nonce);
+
                 Ok(DavFile::Encrypted {
                     file: Box::new(file),
                     key,
@@ -102,13 +136,13 @@ impl DavFile {
                     encrypted_read_buffer: Vec::new(),
                     write_buffer: Vec::new(),
                     pos: 0,
-                    decrypted_len: decrypted_size(metadata.len()),
+                    decrypted_len: cipher_type.decrypted_size(metadata.len()),
                     nonce,
                     offset_in_chunk: 0,
                     read_chunk_idx: 0,
                     write_chunk_idx: write_chunk_idx_initial,
                     seeked_after_open: false,
-                    stream_encryptor,
+                    cipher,
                     write_op_in_progress: false,
                 })
             }
@@ -165,9 +199,12 @@ impl AsyncRead for DavFile {
                 pos,
                 offset_in_chunk,
                 read_chunk_idx,
-                stream_encryptor,
+                cipher,
                 ..
             } => {
+                let plain_chunk_size = cipher.plain_chunk_size();
+                let cipher_type = cipher.cipher_type();
+                let encrypted_chunk_size = plain_chunk_size + cipher_type.overhead();
                 // first, return any leftover plaintext
                 if !read_buffer.is_empty() {
                     let len = std::cmp::min(buf.remaining(), read_buffer.len());
@@ -182,10 +219,10 @@ impl AsyncRead for DavFile {
                 }
 
                 // fill encrypted_read_buffer to at least one chunk
-                while encrypted_read_buffer.len() < ENCRYPTED_CHUNK_SIZE {
-                    let mut tmp = vec![0u8; ENCRYPTED_CHUNK_SIZE - encrypted_read_buffer.len()];
+                while encrypted_read_buffer.len() < encrypted_chunk_size {
+                    let mut tmp = vec![0u8; encrypted_chunk_size - encrypted_read_buffer.len()];
                     let mut read_buf = ReadBuf::new(&mut tmp);
-                    match Pin::new(&mut *file).poll_read(cx, &mut read_buf) {
+                    match Pin::new(&mut **file).poll_read(cx, &mut read_buf) {
                         Poll::Ready(Ok(())) => {
                             let n = read_buf.filled().len();
                             if n == 0 {
@@ -206,26 +243,9 @@ impl AsyncRead for DavFile {
                     return Poll::Ready(Ok(()));
                 }
 
-                let is_last = encrypted_read_buffer.len() < ENCRYPTED_CHUNK_SIZE;
+                let is_last = encrypted_read_buffer.len() < encrypted_chunk_size;
 
-                /*
-                /// FOR TEST PURPOSE ONLY ////
-                let hash = Sha256::digest(&encrypted_read_buffer);
-                let fp = hash
-                    .iter()
-                    .map(|b| format!("{:02x}", b))
-                    .collect::<String>();
-
-                eprintln!(
-                    "READ chunk_idx={} len={} fp={} is_last={is_last} pos={pos}",
-                    *read_chunk_idx,
-                    encrypted_read_buffer.len(),
-                    fp
-                );
-                ////
-                */
-
-                let mut plaintext = stream_encryptor
+                let mut plaintext = cipher
                     .decrypt(*read_chunk_idx, is_last, encrypted_read_buffer.as_slice())
                     .map_err(|e| io::Error::other(format!("Decryption error: {e}")))?;
 
@@ -273,7 +293,7 @@ impl AsyncWrite for DavFile {
                 decrypted_len,
                 write_chunk_idx,
                 seeked_after_open,
-                stream_encryptor,
+                cipher,
                 write_op_in_progress,
                 ..
             } => {
@@ -296,7 +316,7 @@ impl AsyncWrite for DavFile {
                     file,
                     write_buffer,
                     write_chunk_idx,
-                    stream_encryptor,
+                    cipher,
                     false,
                 ) {
                     Poll::Ready(Ok(())) => {
@@ -321,7 +341,7 @@ impl AsyncWrite for DavFile {
                 write_buffer,
                 write_chunk_idx,
                 seeked_after_open,
-                stream_encryptor,
+                cipher,
                 ..
             } => {
                 if *seeked_after_open {
@@ -335,10 +355,10 @@ impl AsyncWrite for DavFile {
                     file,
                     write_buffer,
                     write_chunk_idx,
-                    stream_encryptor,
+                    cipher,
                     false
                 ))?;
-                Pin::new(file).poll_flush(cx)
+                Pin::new(&mut **file).poll_flush(cx)
             }
         }
     }
@@ -353,7 +373,7 @@ impl AsyncWrite for DavFile {
                 write_buffer,
                 write_chunk_idx,
                 seeked_after_open,
-                stream_encryptor,
+                cipher,
                 ..
             } => {
                 if *seeked_after_open {
@@ -367,10 +387,10 @@ impl AsyncWrite for DavFile {
                     file,
                     write_buffer,
                     write_chunk_idx,
-                    stream_encryptor,
+                    cipher,
                     true
                 ))?;
-                Pin::new(file).poll_shutdown(cx)
+                Pin::new(&mut **file).poll_shutdown(cx)
             }
         }
     }
@@ -389,6 +409,7 @@ impl AsyncSeek for DavFile {
                 offset_in_chunk,
                 read_chunk_idx,
                 seeked_after_open,
+                cipher,
                 ..
             } => {
                 *seeked_after_open = true;
@@ -409,10 +430,12 @@ impl AsyncSeek for DavFile {
                 read_buffer.clear();
                 encrypted_read_buffer.clear();
 
-                let encrypted_pos = encrypted_chunk_start(*pos);
-                *offset_in_chunk = *pos as u32 % PLAIN_CHUNK_SIZE as u32;
-                *read_chunk_idx = *pos as u32 / PLAIN_CHUNK_SIZE as u32;
-                Pin::new(file).start_seek(SeekFrom::Start(encrypted_pos))
+                let plain_chunk_size = cipher.plain_chunk_size();
+                let cipher_type = cipher.cipher_type();
+                let encrypted_pos = cipher_type.encrypted_chunk_start(*pos);
+                *offset_in_chunk = (*pos % plain_chunk_size as u64) as u32;
+                *read_chunk_idx = (*pos / plain_chunk_size as u64) as u32;
+                Pin::new(&mut **file).start_seek(SeekFrom::Start(encrypted_pos))
             }
         }
     }
@@ -421,30 +444,15 @@ impl AsyncSeek for DavFile {
         match self.get_mut() {
             DavFile::Plain(file) => Pin::new(file).poll_complete(cx),
             DavFile::Encrypted { file, pos, .. } => {
-                ready!(Pin::new(file).poll_complete(cx))?;
+                ready!(Pin::new(&mut **file).poll_complete(cx))?;
                 Poll::Ready(Ok(*pos))
             }
         }
     }
 }
 
-fn encrypted_chunk_start(dec_offset: u64) -> u64 {
-    let chunk_idx = dec_offset / PLAIN_CHUNK_SIZE as u64;
-    NONCE_SIZE as u64 + chunk_idx * ENCRYPTED_CHUNK_SIZE as u64
-}
-
 pub fn decrypted_size(enc_size: u64) -> u64 {
-    if enc_size <= NONCE_SIZE as u64 {
-        return 0;
-    }
-    let enc_size_without_nonce = enc_size - NONCE_SIZE as u64;
-    let num_chunks = enc_size_without_nonce.div_ceil(ENCRYPTED_CHUNK_SIZE as u64);
-    if num_chunks == 0 {
-        return 0;
-    }
-    let last_chunk_size = enc_size_without_nonce - (num_chunks - 1) * ENCRYPTED_CHUNK_SIZE as u64;
-    (num_chunks - 1) * PLAIN_CHUNK_SIZE as u64
-        + (last_chunk_size.saturating_sub(ENCRYPTION_OVERHEAD as u64))
+    CipherType::XChaCha20Poly1305_1M.decrypted_size(enc_size)
 }
 
 fn poll_write_chunks(
@@ -452,35 +460,20 @@ fn poll_write_chunks(
     file: &mut File,
     write_buffer: &mut Vec<u8>,
     write_chunk_idx: &mut u32,
-    stream_encryptor: &mut StreamBE32<XChaCha20Poly1305>,
+    cipher: &mut Box<dyn Cipher>,
     finalize: bool,
 ) -> Poll<io::Result<()>> {
-    while write_buffer.len() >= PLAIN_CHUNK_SIZE || (finalize && !write_buffer.is_empty()) {
-        let is_last = finalize && write_buffer.len() <= PLAIN_CHUNK_SIZE;
-        let chunk_len = std::cmp::min(write_buffer.len(), PLAIN_CHUNK_SIZE);
+    let plain_chunk_size = cipher.plain_chunk_size();
+    while write_buffer.len() >= plain_chunk_size || (finalize && !write_buffer.is_empty()) {
+        let is_last = finalize && write_buffer.len() <= plain_chunk_size;
+        let chunk_len = std::cmp::min(write_buffer.len(), plain_chunk_size);
         let chunk = write_buffer
             .get(..chunk_len)
             .ok_or(io::Error::other(BUFFER_ERROR))?;
 
-        let ciphertext = stream_encryptor
+        let ciphertext = cipher
             .encrypt(*write_chunk_idx, is_last, chunk)
             .map_err(|e| io::Error::other(format!("Encryption error: {}", e)))?;
-
-        /*
-        //// FOR TEST PURPOSE ONLY ////
-        let hash = Sha256::digest(&ciphertext);
-        let fp = hash
-            .iter()
-            .map(|b| format!("{:02x}", b))
-            .collect::<String>();
-        eprintln!(
-            "WROTE chunk_idx={} len={} fp={}",
-            *write_chunk_idx,
-            ciphertext.len(),
-            fp
-        );
-        ////
-        */
 
         // write the ciphertext fully to disk
         let mut written = 0;
@@ -512,26 +505,6 @@ mod tests {
     use super::*;
     use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 
-    #[test]
-    fn test_decrypted_size() {
-        let nonce_size = NONCE_SIZE as u64;
-        let encryption_overhead = ENCRYPTION_OVERHEAD as u64;
-        let encrypted_chunk_size = ENCRYPTED_CHUNK_SIZE as u64;
-        let plain_chunk_size = PLAIN_CHUNK_SIZE as u64;
-
-        assert_eq!(decrypted_size(0), 0);
-        assert_eq!(decrypted_size(nonce_size + encryption_overhead), 0);
-        assert_eq!(
-            decrypted_size(nonce_size + 3 * encrypted_chunk_size),
-            3 * plain_chunk_size
-        );
-        assert_eq!(
-            decrypted_size(
-                nonce_size + 3 * encrypted_chunk_size + ENCRYPTION_OVERHEAD as u64 + 150
-            ),
-            3 * plain_chunk_size + 150
-        );
-    }
 
     #[tokio::test]
     async fn test_plain_file() -> io::Result<()> {
@@ -610,7 +583,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("large.txt.enc");
         let key = [42u8; 32];
-        let content = vec![0xAB; PLAIN_CHUNK_SIZE * 3 + 123];
+        let content = vec![0xAB; 1_000_000 * 3 + 123];
 
         let mut file = DavFile::create(&path, Some(key)).await?;
         file.write_all(&content).await?;
@@ -625,6 +598,7 @@ mod tests {
 
         Ok(())
     }
+
 
     #[tokio::test]
     async fn test_encrypted_file_truncated() -> io::Result<()> {
@@ -664,11 +638,12 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("large.txt.enc");
         let key = [42u8; 32];
-        let mut content = vec![0u8; PLAIN_CHUNK_SIZE * 2];
-        for i in 0..PLAIN_CHUNK_SIZE {
+        let plain_chunk_size = 1_000_000;
+        let mut content = vec![0u8; plain_chunk_size * 2];
+        for i in 0..plain_chunk_size {
             content[i] = 0xAA;
         }
-        for i in PLAIN_CHUNK_SIZE..(PLAIN_CHUNK_SIZE * 2) {
+        for i in plain_chunk_size..(plain_chunk_size * 2) {
             content[i] = 0xBB;
         }
 
@@ -677,12 +652,12 @@ mod tests {
         file.shutdown().await?;
 
         let mut file = DavFile::open(&path, Some(key)).await?;
-        file.seek(SeekFrom::Start((PLAIN_CHUNK_SIZE - 5) as u64))
+        file.seek(SeekFrom::Start((plain_chunk_size - 5) as u64))
             .await?;
         let mut buf = [0u8; 10];
         file.read_exact(&mut buf).await?;
 
-        assert_eq!(&buf, &content[PLAIN_CHUNK_SIZE - 5..PLAIN_CHUNK_SIZE + 5]);
+        assert_eq!(&buf, &content[plain_chunk_size - 5..plain_chunk_size + 5]);
 
         Ok(())
     }
@@ -692,7 +667,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("large_byte_by_byte.txt.enc");
         let key = [88u8; 32];
-        let content = vec![0xAB; PLAIN_CHUNK_SIZE * 2 + 555];
+        let content = vec![0xAB; 1_000_000 * 2 + 555];
 
         let mut file = DavFile::create(&path, Some(key)).await?;
         file.write_all(&content).await?;

--- a/backend/src/davs/dav_file.rs
+++ b/backend/src/davs/dav_file.rs
@@ -1,4 +1,4 @@
-use super::crypto::{Cipher, CipherType, create_cipher};
+use super::crypto::{Cipher, CipherType};
 use futures::ready;
 use headers::{ETag, LastModified};
 use rand::{TryRng, rngs::SysRng};
@@ -14,22 +14,46 @@ const BUFFER_ERROR: &str = "buffer error for encryption or decryption";
 
 pub enum DavFile {
     Plain(File),
-    Encrypted {
-        file: Box<File>,
-        key: [u8; 32],
-        read_buffer: Vec<u8>,
-        encrypted_read_buffer: Vec<u8>,
-        write_buffer: Vec<u8>,
-        pos: u64,
-        decrypted_len: u64,
-        nonce: Vec<u8>,
-        offset_in_chunk: u32,
-        read_chunk_idx: u32,
-        write_chunk_idx: u32,
-        seeked_after_open: bool,
+    Encrypted(EncryptedFile),
+}
+
+pub struct EncryptedFile {
+    file: Box<File>,
+    read_buffer: Vec<u8>,
+    encrypted_read_buffer: Vec<u8>,
+    write_buffer: Vec<u8>,
+    pos: u64,
+    decrypted_len: u64,
+    offset_in_chunk: u32,
+    read_chunk_idx: u32,
+    write_chunk_idx: u32,
+    seeked_after_open: bool,
+    cipher: Box<dyn Cipher>,
+    write_op_in_progress: bool,
+}
+
+impl EncryptedFile {
+    fn new(
+        file: File,
         cipher: Box<dyn Cipher>,
-        write_op_in_progress: bool,
-    },
+        decrypted_len: u64,
+        write_chunk_idx: u32,
+    ) -> Self {
+        Self {
+            file: Box::new(file),
+            cipher,
+            decrypted_len,
+            write_chunk_idx,
+            read_buffer: Vec::new(),
+            encrypted_read_buffer: Vec::new(),
+            write_buffer: Vec::new(),
+            pos: 0,
+            offset_in_chunk: 0,
+            read_chunk_idx: 0,
+            seeked_after_open: false,
+            write_op_in_progress: false,
+        }
+    }
 }
 
 impl DavFile {
@@ -56,24 +80,11 @@ impl DavFile {
                 file.write_all(&nonce).await?;
                 file.flush().await?;
 
-                let cipher = create_cipher(cipher_type, &key, &nonce);
+                let cipher = cipher_type.create_cipher(&key, &nonce);
 
-                Ok(DavFile::Encrypted {
-                    file: Box::new(file),
-                    key,
-                    read_buffer: Vec::new(),
-                    encrypted_read_buffer: Vec::new(),
-                    write_buffer: Vec::new(),
-                    pos: 0,
-                    decrypted_len: 0,
-                    nonce,
-                    offset_in_chunk: 0,
-                    read_chunk_idx: 0,
-                    write_chunk_idx: 0,
-                    seeked_after_open: false,
-                    cipher,
-                    write_op_in_progress: false,
-                })
+                Ok(DavFile::Encrypted(EncryptedFile::new(
+                    file, cipher, 0, 0,
+                )))
             }
             None => Ok(DavFile::Plain(file)),
         }
@@ -92,23 +103,10 @@ impl DavFile {
                     let cipher_type = CipherType::XChaCha20Poly1305_1M;
                     let nonce_size = cipher_type.nonce_size();
                     let nonce = vec![0u8; nonce_size];
-                    let cipher = create_cipher(cipher_type, &key, &nonce);
-                    return Ok(DavFile::Encrypted {
-                        file: Box::new(file),
-                        key,
-                        read_buffer: Vec::new(),
-                        encrypted_read_buffer: Vec::new(),
-                        write_buffer: Vec::new(),
-                        pos: 0,
-                        decrypted_len: 0,
-                        nonce,
-                        offset_in_chunk: 0,
-                        read_chunk_idx: 0,
-                        write_chunk_idx: 0,
-                        seeked_after_open: false,
-                        cipher,
-                        write_op_in_progress: false,
-                    });
+                    let cipher = cipher_type.create_cipher(&key, &nonce);
+                    return Ok(DavFile::Encrypted(EncryptedFile::new(
+                        file, cipher, 0, 0,
+                    )));
                 }
 
                 let mut cipher_type_byte = [0u8; 1];
@@ -127,24 +125,14 @@ impl DavFile {
                 let write_chunk_idx_initial =
                     (enc_size_without_header / encrypted_chunk_size as u64) as u32;
 
-                let cipher = create_cipher(cipher_type, &key, &nonce);
+                let cipher = cipher_type.create_cipher(&key, &nonce);
 
-                Ok(DavFile::Encrypted {
-                    file: Box::new(file),
-                    key,
-                    read_buffer: Vec::new(),
-                    encrypted_read_buffer: Vec::new(),
-                    write_buffer: Vec::new(),
-                    pos: 0,
-                    decrypted_len: cipher_type.decrypted_size(metadata.len()),
-                    nonce,
-                    offset_in_chunk: 0,
-                    read_chunk_idx: 0,
-                    write_chunk_idx: write_chunk_idx_initial,
-                    seeked_after_open: false,
+                Ok(DavFile::Encrypted(EncryptedFile::new(
+                    file,
                     cipher,
-                    write_op_in_progress: false,
-                })
+                    cipher_type.decrypted_size(metadata.len()),
+                    write_chunk_idx_initial,
+                )))
             }
             None => Ok(DavFile::Plain(file)),
         }
@@ -153,7 +141,7 @@ impl DavFile {
     pub async fn len(&self) -> u64 {
         match self {
             DavFile::Plain(file) => file.metadata().await.map_or(0, |m| m.len()),
-            DavFile::Encrypted { decrypted_len, .. } => *decrypted_len,
+            DavFile::Encrypted(f) => f.decrypted_len,
         }
     }
 
@@ -164,7 +152,7 @@ impl DavFile {
     pub async fn cache_headers(&self) -> Option<(ETag, LastModified)> {
         let metadata = match match self {
             DavFile::Plain(file) => file.metadata().await,
-            DavFile::Encrypted { file, .. } => file.metadata().await,
+            DavFile::Encrypted(f) => f.file.metadata().await,
         } {
             Ok(m) => m,
             Err(_) => return None,
@@ -192,43 +180,34 @@ impl AsyncRead for DavFile {
     ) -> Poll<io::Result<()>> {
         match self.get_mut() {
             DavFile::Plain(file) => Pin::new(file).poll_read(cx, buf),
-            DavFile::Encrypted {
-                file,
-                read_buffer,
-                encrypted_read_buffer,
-                pos,
-                offset_in_chunk,
-                read_chunk_idx,
-                cipher,
-                ..
-            } => {
-                let plain_chunk_size = cipher.plain_chunk_size();
-                let cipher_type = cipher.cipher_type();
+            DavFile::Encrypted(f) => {
+                let plain_chunk_size = f.cipher.plain_chunk_size();
+                let cipher_type = f.cipher.cipher_type();
                 let encrypted_chunk_size = plain_chunk_size + cipher_type.overhead();
                 // first, return any leftover plaintext
-                if !read_buffer.is_empty() {
-                    let len = std::cmp::min(buf.remaining(), read_buffer.len());
+                if !f.read_buffer.is_empty() {
+                    let len = std::cmp::min(buf.remaining(), f.read_buffer.len());
                     buf.put_slice(
-                        read_buffer
+                        f.read_buffer
                             .get(..len)
                             .ok_or(io::Error::other(BUFFER_ERROR))?,
                     );
-                    read_buffer.drain(..len);
-                    *pos += len as u64;
+                    f.read_buffer.drain(..len);
+                    f.pos += len as u64;
                     return Poll::Ready(Ok(()));
                 }
 
                 // fill encrypted_read_buffer to at least one chunk
-                while encrypted_read_buffer.len() < encrypted_chunk_size {
-                    let mut tmp = vec![0u8; encrypted_chunk_size - encrypted_read_buffer.len()];
+                while f.encrypted_read_buffer.len() < encrypted_chunk_size {
+                    let mut tmp = vec![0u8; encrypted_chunk_size - f.encrypted_read_buffer.len()];
                     let mut read_buf = ReadBuf::new(&mut tmp);
-                    match Pin::new(&mut **file).poll_read(cx, &mut read_buf) {
+                    match Pin::new(&mut *f.file).poll_read(cx, &mut read_buf) {
                         Poll::Ready(Ok(())) => {
                             let n = read_buf.filled().len();
                             if n == 0 {
                                 break; // EOF
                             }
-                            encrypted_read_buffer.extend_from_slice(
+                            f.encrypted_read_buffer.extend_from_slice(
                                 tmp.get(..n).ok_or(io::Error::other(BUFFER_ERROR))?,
                             );
                         }
@@ -239,39 +218,39 @@ impl AsyncRead for DavFile {
                     }
                 }
 
-                if encrypted_read_buffer.is_empty() {
+                if f.encrypted_read_buffer.is_empty() {
                     return Poll::Ready(Ok(()));
                 }
 
-                let is_last = encrypted_read_buffer.len() < encrypted_chunk_size;
+                let is_last = f.encrypted_read_buffer.len() < encrypted_chunk_size;
 
-                let mut plaintext = cipher
-                    .decrypt(*read_chunk_idx, is_last, encrypted_read_buffer.as_slice())
+                let mut plaintext = f.cipher
+                    .decrypt(f.read_chunk_idx, is_last, f.encrypted_read_buffer.as_slice())
                     .map_err(|e| io::Error::other(format!("Decryption error: {e}")))?;
 
-                encrypted_read_buffer.clear();
-                *read_chunk_idx += 1;
+                f.encrypted_read_buffer.clear();
+                f.read_chunk_idx += 1;
 
                 // apply offset_in_chunk if needed
-                if *offset_in_chunk > 0 {
-                    let offset = *offset_in_chunk as usize;
+                if f.offset_in_chunk > 0 {
+                    let offset = f.offset_in_chunk as usize;
                     if offset < plaintext.len() {
                         plaintext.drain(..offset);
                     } else {
                         plaintext.clear();
                     }
-                    *offset_in_chunk = 0;
+                    f.offset_in_chunk = 0;
                 }
 
                 // fill the user buffer and keep remainder in read_buffer
                 let len = std::cmp::min(buf.remaining(), plaintext.len());
                 buf.put_slice(plaintext.get(..len).ok_or(io::Error::other(BUFFER_ERROR))?);
                 if len < plaintext.len() {
-                    read_buffer.extend_from_slice(
+                    f.read_buffer.extend_from_slice(
                         plaintext.get(len..).ok_or(io::Error::other(BUFFER_ERROR))?,
                     );
                 }
-                *pos += len as u64;
+                f.pos += len as u64;
 
                 Poll::Ready(Ok(()))
             }
@@ -287,44 +266,35 @@ impl AsyncWrite for DavFile {
     ) -> Poll<io::Result<usize>> {
         match self.get_mut() {
             DavFile::Plain(file) => Pin::new(file).poll_write(cx, buf),
-            DavFile::Encrypted {
-                file,
-                write_buffer,
-                decrypted_len,
-                write_chunk_idx,
-                seeked_after_open,
-                cipher,
-                write_op_in_progress,
-                ..
-            } => {
-                if *seeked_after_open {
+            DavFile::Encrypted(f) => {
+                if f.seeked_after_open {
                     return Poll::Ready(Err(io::Error::new(
                         io::ErrorKind::Unsupported,
                         "writing after seek is not supported for encrypted files",
                     )));
                 }
 
-                if !*write_op_in_progress {
-                    write_buffer.extend_from_slice(buf);
-                    *decrypted_len += buf.len() as u64;
+                if !f.write_op_in_progress {
+                    f.write_buffer.extend_from_slice(buf);
+                    f.decrypted_len += buf.len() as u64;
                 }
 
-                *write_op_in_progress = true;
+                f.write_op_in_progress = true;
 
                 match poll_write_chunks(
                     cx,
-                    file,
-                    write_buffer,
-                    write_chunk_idx,
-                    cipher,
+                    &mut f.file,
+                    &mut f.write_buffer,
+                    &mut f.write_chunk_idx,
+                    &mut f.cipher,
                     false,
                 ) {
                     Poll::Ready(Ok(())) => {
-                        *write_op_in_progress = false;
+                        f.write_op_in_progress = false;
                         Poll::Ready(Ok(buf.len()))
                     }
                     Poll::Ready(Err(e)) => {
-                        *write_op_in_progress = false;
+                        f.write_op_in_progress = false;
                         Poll::Ready(Err(e))
                     }
                     Poll::Pending => Poll::Pending,
@@ -336,15 +306,8 @@ impl AsyncWrite for DavFile {
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         match self.get_mut() {
             DavFile::Plain(file) => Pin::new(file).poll_flush(cx),
-            DavFile::Encrypted {
-                file,
-                write_buffer,
-                write_chunk_idx,
-                seeked_after_open,
-                cipher,
-                ..
-            } => {
-                if *seeked_after_open {
+            DavFile::Encrypted(f) => {
+                if f.seeked_after_open {
                     return Poll::Ready(Err(io::Error::new(
                         io::ErrorKind::Unsupported,
                         "writing after seek is not supported for encrypted files",
@@ -352,13 +315,13 @@ impl AsyncWrite for DavFile {
                 }
                 ready!(poll_write_chunks(
                     cx,
-                    file,
-                    write_buffer,
-                    write_chunk_idx,
-                    cipher,
+                    &mut f.file,
+                    &mut f.write_buffer,
+                    &mut f.write_chunk_idx,
+                    &mut f.cipher,
                     false
                 ))?;
-                Pin::new(&mut **file).poll_flush(cx)
+                Pin::new(&mut *f.file).poll_flush(cx)
             }
         }
     }
@@ -368,15 +331,8 @@ impl AsyncWrite for DavFile {
         let me = self.get_mut();
         match me {
             DavFile::Plain(file) => Pin::new(file).poll_shutdown(cx),
-            DavFile::Encrypted {
-                file,
-                write_buffer,
-                write_chunk_idx,
-                seeked_after_open,
-                cipher,
-                ..
-            } => {
-                if *seeked_after_open {
+            DavFile::Encrypted(f) => {
+                if f.seeked_after_open {
                     return Poll::Ready(Err(io::Error::new(
                         io::ErrorKind::Unsupported,
                         "writing after seek is not supported for encrypted files",
@@ -384,13 +340,13 @@ impl AsyncWrite for DavFile {
                 }
                 ready!(poll_write_chunks(
                     cx,
-                    file,
-                    write_buffer,
-                    write_chunk_idx,
-                    cipher,
+                    &mut f.file,
+                    &mut f.write_buffer,
+                    &mut f.write_chunk_idx,
+                    &mut f.cipher,
                     true
                 ))?;
-                Pin::new(&mut **file).poll_shutdown(cx)
+                Pin::new(&mut *f.file).poll_shutdown(cx)
             }
         }
     }
@@ -400,23 +356,12 @@ impl AsyncSeek for DavFile {
     fn start_seek(self: Pin<&mut Self>, position: SeekFrom) -> io::Result<()> {
         match self.get_mut() {
             DavFile::Plain(file) => Pin::new(file).start_seek(position),
-            DavFile::Encrypted {
-                file,
-                pos,
-                decrypted_len,
-                read_buffer,
-                encrypted_read_buffer,
-                offset_in_chunk,
-                read_chunk_idx,
-                seeked_after_open,
-                cipher,
-                ..
-            } => {
-                *seeked_after_open = true;
+            DavFile::Encrypted(f) => {
+                f.seeked_after_open = true;
                 let new_pos = match position {
                     SeekFrom::Start(p) => p as i64,
-                    SeekFrom::End(p) => *decrypted_len as i64 + p,
-                    SeekFrom::Current(p) => *pos as i64 + p,
+                    SeekFrom::End(p) => f.decrypted_len as i64 + p,
+                    SeekFrom::Current(p) => f.pos as i64 + p,
                 };
 
                 if new_pos < 0 {
@@ -426,16 +371,16 @@ impl AsyncSeek for DavFile {
                     ));
                 }
 
-                *pos = new_pos as u64;
-                read_buffer.clear();
-                encrypted_read_buffer.clear();
+                f.pos = new_pos as u64;
+                f.read_buffer.clear();
+                f.encrypted_read_buffer.clear();
 
-                let plain_chunk_size = cipher.plain_chunk_size();
-                let cipher_type = cipher.cipher_type();
-                let encrypted_pos = cipher_type.encrypted_chunk_start(*pos);
-                *offset_in_chunk = (*pos % plain_chunk_size as u64) as u32;
-                *read_chunk_idx = (*pos / plain_chunk_size as u64) as u32;
-                Pin::new(&mut **file).start_seek(SeekFrom::Start(encrypted_pos))
+                let plain_chunk_size = f.cipher.plain_chunk_size();
+                let cipher_type = f.cipher.cipher_type();
+                let encrypted_pos = cipher_type.encrypted_chunk_start(f.pos);
+                f.offset_in_chunk = (f.pos % plain_chunk_size as u64) as u32;
+                f.read_chunk_idx = (f.pos / plain_chunk_size as u64) as u32;
+                Pin::new(&mut *f.file).start_seek(SeekFrom::Start(encrypted_pos))
             }
         }
     }
@@ -443,16 +388,28 @@ impl AsyncSeek for DavFile {
     fn poll_complete(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
         match self.get_mut() {
             DavFile::Plain(file) => Pin::new(file).poll_complete(cx),
-            DavFile::Encrypted { file, pos, .. } => {
-                ready!(Pin::new(&mut **file).poll_complete(cx))?;
-                Poll::Ready(Ok(*pos))
+            DavFile::Encrypted(f) => {
+                ready!(Pin::new(&mut *f.file).poll_complete(cx))?;
+                Poll::Ready(Ok(f.pos))
             }
         }
     }
 }
 
-pub fn decrypted_size(enc_size: u64) -> u64 {
-    CipherType::XChaCha20Poly1305_1M.decrypted_size(enc_size)
+pub async fn decrypted_size_from_file(path: &Path, enc_size: u64) -> u64 {
+    if enc_size == 0 {
+        return 0;
+    }
+    match fs::File::open(path).await {
+        Ok(mut file) => {
+            let mut cipher_type_byte = [0u8; 1];
+            if file.read_exact(&mut cipher_type_byte).await.is_ok() && let Ok(cipher_type) = CipherType::from_u8(cipher_type_byte[0]) {
+                return cipher_type.decrypted_size(enc_size);
+            }
+            0
+        }
+        Err(_) => 0,
+    }
 }
 
 fn poll_write_chunks(

--- a/backend/src/davs/mod.rs
+++ b/backend/src/davs/mod.rs
@@ -1,3 +1,4 @@
+pub mod crypto;
 pub mod dav_file;
 pub mod error;
 pub(crate) mod headers;

--- a/backend/src/davs/webdav_server.rs
+++ b/backend/src/davs/webdav_server.rs
@@ -22,7 +22,9 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
-use super::{dav_file::decrypted_size, headers::Depth, model::Dav};
+use super::{
+    dav_file::{decrypted_size_from_file}, headers::Depth, model::Dav,
+};
 use crate::{
     davs::{dav_file::DavFile, headers::Overwrite},
     utils::extract_query_pairs,
@@ -895,7 +897,7 @@ impl WebdavServer {
         let size = match path_type {
             PathType::Dir | PathType::SymlinkDir => None,
             PathType::File | PathType::SymlinkFile => Some(if key.is_some() {
-                decrypted_size(meta.len())
+                decrypted_size_from_file(path, meta.len()).await
             } else {
                 meta.len()
             }),

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -208,6 +208,7 @@ fn setup_logger(debug_mode: bool, log_to_file: bool) -> Vec<WorkerGuard> {
         guards.push(guard);
         let file_writer = fmt::Layer::new()
             .with_ansi(false)
+            .with_target(false)
             .with_timer(timer)
             .with_writer(non_blocking);
         Some(file_writer)

--- a/backend/src/onlyoffice.rs
+++ b/backend/src/onlyoffice.rs
@@ -10,6 +10,7 @@ use axum::{
     extract::{RawQuery, State},
     response::{Html, IntoResponse},
 };
+use base64ct::{Base64, Encoding};
 use http::{Method, Request, StatusCode, header, header::CONTENT_TYPE};
 use hyper_rustls::HttpsConnectorBuilder;
 use hyper_util::{client::legacy::Client, rt::TokioExecutor};
@@ -99,9 +100,7 @@ pub async fn onlyoffice_page(
         .map_err(|_| QUERY_ERROR)?;
         let url = format!("{file}?token={share_token}");
 
-        let mut hasher = Sha256::new();
-        hasher.update(format!("{file}{mtime}"));
-        let key: String = format!("{:X}", hasher.finalize());
+        let key = Base64::encode_string(&Sha256::digest(format!("{file}{mtime}")));
 
         let mut ooconf = OnlyOfficeConfiguration {
             document: Document {

--- a/backend/src/onlyoffice.rs
+++ b/backend/src/onlyoffice.rs
@@ -10,7 +10,6 @@ use axum::{
     extract::{RawQuery, State},
     response::{Html, IntoResponse},
 };
-use base64ct::{Base64, Encoding};
 use http::{Method, Request, StatusCode, header, header::CONTENT_TYPE};
 use hyper_rustls::HttpsConnectorBuilder;
 use hyper_util::{client::legacy::Client, rt::TokioExecutor};
@@ -100,7 +99,10 @@ pub async fn onlyoffice_page(
         .map_err(|_| QUERY_ERROR)?;
         let url = format!("{file}?token={share_token}");
 
-        let key = Base64::encode_string(&Sha256::digest(format!("{file}{mtime}")));
+        let key = Sha256::digest(format!("{file}{mtime}"))
+            .iter()
+            .map(|b| format!("{:02x}", b))
+            .collect::<String>();
 
         let mut ooconf = OnlyOfficeConfiguration {
             document: Document {

--- a/backend/tests/backend/davs.rs
+++ b/backend/tests/backend/davs.rs
@@ -7,7 +7,7 @@ use quick_xml::escape::escape;
 use sha2::{Digest, Sha512};
 use std::{
     fs,
-    io::{self, BufWriter, Write},
+    io::{self, BufWriter, Read},
     time::{Duration, Instant},
 };
 use tokio::fs::File;
@@ -123,12 +123,10 @@ async fn put_and_get_file(
     wanted_content: &str,
     encrypted: bool,
 ) -> BoxResult<()> {
-    let mut file = std::fs::File::open(format!("tests/data/{file_name}"))?;
+    let file = std::fs::File::open(format!("tests/data/{file_name}"))?;
 
-    let mut hasher = Sha512::new();
-    io::copy(&mut file, &mut hasher)?;
-    let hash_source = hasher.finalize();
-    println!("Source file hash: {}", Base64::encode_string(&hash_source));
+    let hash_source = file_hash(file)?;
+    println!("Source file hash: {}", hash_source);
 
     let file = File::open(format!("tests/data/{file_name}")).await?;
     // Act : send the file
@@ -145,11 +143,9 @@ async fn put_and_get_file(
     } else {
         format!("data/{}/dir2/{file_name}", app.id)
     };
-    let mut stored_file = std::fs::File::open(stored_file_path)?;
-    let mut hasher = Sha512::new();
-    io::copy(&mut stored_file, &mut hasher)?;
-    let hash_stored = hasher.finalize();
-    println!("Stored file hash: {}", Base64::encode_string(&hash_stored));
+    let stored_file = std::fs::File::open(stored_file_path)?;
+    let hash_stored = file_hash(stored_file)?;
+    println!("Stored file hash: {}", hash_stored);
     // Assert that the stored file is the same as the send file... or not if it it encrypted
     if !encrypted {
         assert_eq!(hash_source, hash_stored);
@@ -174,16 +170,28 @@ async fn put_and_get_file(
     let mut hasher = Sha512::new();
     while let Some(item) = stream.next().await {
         let chunk = item?;
-        hasher.write_all(&chunk)?;
+        hasher.update(&chunk);
     }
-    let hash_retrieved = hasher.finalize();
-    println!(
-        "Retrieved file hash: {}",
-        Base64::encode_string(&hash_retrieved)
-    );
+    let hash_retrieved = Base64::encode_string(&hasher.finalize());
+    println!("Retrieved file hash: {}", hash_retrieved);
     // Assert that the retrieved file is the same as the original file
     assert_eq!(hash_source, hash_retrieved);
     Ok(())
+}
+
+fn file_hash(mut file: fs::File) -> Result<String, io::Error> {
+    let mut hasher = Sha512::new();
+    let mut buffer = [0u8; 8192];
+    loop {
+        let n = file.read(&mut buffer)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buffer[..n]);
+    }
+    let hash_source = hasher.finalize();
+    let hash_source = Base64::encode_string(&hash_source);
+    Ok(hash_source)
 }
 
 fn file_to_body(file: File) -> reqwest::Body {


### PR DESCRIPTION
This change modifies the logging configuration in `backend/src/main.rs` to remove the module path (e.g., `atrium::auth::middlewares`) from log entries written to files. This is achieved by adding `.with_target(false)` to the `file_writer` layer. Console logs remain unaffected.

---
*PR created automatically by Jules for task [16714246902775320675](https://jules.google.com/task/16714246902775320675) started by @nicolaspernoud*